### PR TITLE
always provide quality information within the imgproxy uri

### DIFF
--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -24,6 +24,12 @@ class ThumbnailAspect
     protected $settings;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Media.image.defaultOptions.quality")
+     * @var integer
+     */
+    protected $defaultQuality;
+
+    /**
      * @Flow\Inject
      * @var ResourceManager
      */
@@ -70,8 +76,17 @@ class ThumbnailAspect
 
         $url = $builder->buildUrl($sourceUri);
 
+        // set the quality information if given
+        // otherwise use the format quality string if provided
         if ($configuration->getQuality() !== null) {
             $url->quality($configuration->getQuality());
+        } else {
+            if (!empty($this->settings['formatQuality'])) {
+                $url->formatQuality($this->settings['formatQuality']);
+            } else {
+                // if no settings are provided use neos.media image default quality
+                $url->quality($this->defaultQuality);
+            }
         }
 
         $resizingType = ImgproxyBuilder::RESIZE_TYPE_FIT;

--- a/Classes/ImgproxyUrl.php
+++ b/Classes/ImgproxyUrl.php
@@ -56,4 +56,9 @@ class ImgproxyUrl
     {
         $this->processingOptions[] = 'q:' . $quality;
     }
+
+    public function formatQuality(string $qualityString)
+    {
+        $this->processingOptions[] = 'fq:' . $qualityString;
+    }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,3 +9,6 @@ Networkteam:
 
     # Let imgproxy choose the file extension based on client preferences
     autoFormat: true
+
+    # Quality format string, eg: 'jpg=75,avif=80,webp=70'
+    formatQuality: ''


### PR DESCRIPTION
This MR ensures that a quality parameter is always provided:

- use quality if provided
- use quality_format if provided
- else use `neos.media.image.defaultOptions.quality` as quality setting