### PR TITLE
Feature/allow imgproxy url modification

### DIFF
--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -9,6 +9,7 @@ use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageVariant;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Utility\ObjectAccess;
 use Networkteam\ImageProxy\Eel\SourceUriHelper;
 use Networkteam\ImageProxy\ImgproxyBuilder;
 use Networkteam\ImageProxy\Model\Dimensions;
@@ -108,6 +109,14 @@ class ThumbnailAspect
         $actualDimension = new Dimensions($asset->getWidth(), $asset->getHeight());
 
         $expectedSize = ImgproxyBuilder::expectedSize($actualDimension, $targetDimension, $resizingType, $enlarge);
+
+        $focusPointX = ObjectAccess::getProperty($configuration, 'focusPointX', true);
+        $focusPointY = ObjectAccess::getProperty($configuration, 'focusPointY', true);
+        if($focusPointX && $focusPointY){
+            $focusPointX = ($focusPointX + 1) / 2;
+            $focusPointY = ($focusPointY + 1) / 2;
+            $url->focusPoint($focusPointX, $focusPointY);
+        }
 
         return [
             'width' => $expectedSize->getWidth(),

--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -112,7 +112,7 @@ class ThumbnailAspect
 
         $focusPointX = ObjectAccess::getProperty($configuration, 'focusPointX', true);
         $focusPointY = ObjectAccess::getProperty($configuration, 'focusPointY', true);
-        if($focusPointX && $focusPointY){
+        if(is_float($focusPointX) && is_float($focusPointX)){
             $focusPointX = ($focusPointX + 1) / 2;
             $focusPointY = ($focusPointY + 1) / 2;
             $url->focusPoint($focusPointX, $focusPointY);

--- a/Classes/ImgproxyUrl.php
+++ b/Classes/ImgproxyUrl.php
@@ -77,8 +77,8 @@ class ImgproxyUrl
         $this->processingOptions[] = 'cb:' . $cacheBuster;
     }
 
-    public function focusPoint(float $focusPointX, float $focusPointY)
+    public function addProcessingOption($key, $value)
     {
-        $this->processingOptions[] = 'gravity:fp:' . $focusPointX . ':' . $focusPointY;
+        $this->processingOptions[] = $key . ':' . $value;
     }
 }

--- a/Classes/ImgproxyUrl.php
+++ b/Classes/ImgproxyUrl.php
@@ -76,4 +76,9 @@ class ImgproxyUrl
     {
         $this->processingOptions[] = 'cb:' . $cacheBuster;
     }
+
+    public function focusPoint(float $focusPointX, float $focusPointY)
+    {
+        $this->processingOptions[] = 'gravity:fp:' . $focusPointX . ':' . $focusPointY;
+    }
 }

--- a/Classes/Model/ImgproxyUrlModifierInterface.php
+++ b/Classes/Model/ImgproxyUrlModifierInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Networkteam\ImageProxy\Model;
+
+use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Networkteam\ImageProxy\ImgproxyUrl;
+
+interface ImgproxyUrlModifierInterface
+{
+    public function modify(ImgproxyUrl $url, ThumbnailConfiguration $configuration): void;
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,6 +16,10 @@ Networkteam:
     # Let imgproxy choose the file extension based on client preferences
     autoFormat: true
 
+    # This allows to modify the imgproxy url before it gets returned
+    # All classes listed here must implement the ImgproxyUrlModifierInterface
+    imgproxyUrlModifiers: []
+
     # Format Quality, eg: 'jpg:75:avif:80:webp:70'
     formatQuality: ''
 


### PR DESCRIPTION
This allows to modify the imgproxyUrl before it gets returned. I also added a general method to add custom processing options to the ImgproxyUrl object.

I added a hook functionality since a proper signal doesn't work because the ThumbnailAspect class is an AOP aspect.
If you have any feedback please let me know.


Regards,
Cyrill