### PR TITLE
Feature/imgproxy builder override

### DIFF
--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -9,6 +9,7 @@ use Neos\Media\Domain\Model\Asset;
 use Neos\Media\Domain\Model\Image;
 use Neos\Media\Domain\Model\ImageVariant;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Utility\ObjectAccess;
 use Networkteam\ImageProxy\Eel\SourceUriHelper;
 use Networkteam\ImageProxy\ImgproxyBuilder;
 use Networkteam\ImageProxy\Model\Dimensions;
@@ -108,6 +109,14 @@ class ThumbnailAspect
         $actualDimension = new Dimensions($asset->getWidth(), $asset->getHeight());
 
         $expectedSize = ImgproxyBuilder::expectedSize($actualDimension, $targetDimension, $resizingType, $enlarge);
+
+        $focusPointX = ObjectAccess::getProperty($configuration, 'focusPointX', true);
+        $focusPointY = ObjectAccess::getProperty($configuration, 'focusPointY', true);
+        if($focusPointX && $focusPointY){
+            $focusPointX = ($focusPointX + 1) / 2;
+            $focusPointY = ($focusPointY + 1) / 2;
+            $url->focusPoint($focusPointX, $focusPointY);
+        }
 
         return [
             'width' => $expectedSize->getWidth(),

--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -112,7 +112,7 @@ class ThumbnailAspect
 
         $focusPointX = ObjectAccess::getProperty($configuration, 'focusPointX', true);
         $focusPointY = ObjectAccess::getProperty($configuration, 'focusPointY', true);
-        if($focusPointX && $focusPointY){
+        if(is_float($focusPointX) && is_float($focusPointX)){
             $focusPointX = ($focusPointX + 1) / 2;
             $focusPointY = ($focusPointY + 1) / 2;
             $url->focusPoint($focusPointX, $focusPointY);

--- a/Classes/ImgproxyBuilderInterface.php
+++ b/Classes/ImgproxyBuilderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Networkteam\ImageProxy;
+
+use Networkteam\ImageProxy\Model\Dimensions;
+
+interface ImgproxyBuilderInterface
+{
+    public static function expectedSize(
+        Dimensions $actualDimension,
+        Dimensions $targetDimension,
+        string $resizingType,
+        bool $enlarge
+    ): Dimensions;
+
+    public function buildUrl(string $sourceUrl): ImgproxyUrl;
+
+    public function generateUrl(ImgproxyUrl $imgproxyUrl): string;
+}

--- a/Classes/ImgproxyUrl.php
+++ b/Classes/ImgproxyUrl.php
@@ -76,4 +76,9 @@ class ImgproxyUrl
     {
         $this->processingOptions[] = 'cb:' . $cacheBuster;
     }
+
+    public function focusPoint(float $focusPointX, float $focusPointY)
+    {
+        $this->processingOptions[] = 'gravity:fp:' . $focusPointX . ':' . $focusPointY;
+    }
 }

--- a/Classes/ImgproxyUrl.php
+++ b/Classes/ImgproxyUrl.php
@@ -59,7 +59,7 @@ class ImgproxyUrl
 
     public function build(): string
     {
-        return $this->builder->generateUrl($this->url, $this->processingOptions, $this->extension);
+        return $this->builder->generateUrl($this);
     }
 
     public function quality(int $quality)
@@ -80,5 +80,25 @@ class ImgproxyUrl
     public function focusPoint(float $focusPointX, float $focusPointY)
     {
         $this->processingOptions[] = 'gravity:fp:' . $focusPointX . ':' . $focusPointY;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getExtension(): ?string
+    {
+        return $this->extension;
+    }
+
+    public function getProcessingOptions(): array
+    {
+        return $this->processingOptions;
+    }
+
+    public function addProcessingOption(string $key, string $value)
+    {
+        $this->processingOptions[$key] = $value;
     }
 }


### PR DESCRIPTION
For readability I created a new pull request, I hope this is ok.
Related Pull Request: https://github.com/networkteam/Networkteam.ImageProxy/pull/11

As you mentioned in the related pull request I created an interface for the ImgproxyBuilder class allowing to override it by using the Objects.yaml. Additionally I added the ThumbnailConfiguration object to the ImgproxyBuilder and a addProcessingOption allowing to add processing options inside the generateUrl method using this configuration object.

Example how to override the ImgproxyBuilder class:

Classes/ImgproxyBuilder.php:
```
class ImgproxyBuilder extends ImgproxyBuilderBase
{
    public function generateUrl(ImgproxyUrl $imgproxyUrl): string
    {
        $configuration = $this->thumbnailConfiguration;
        $focusPointX = ObjectAccess::getProperty($configuration, 'focusPointX', true);
        $focusPointY = ObjectAccess::getProperty($configuration, 'focusPointY', true);

        if (is_float($focusPointX) && is_float($focusPointY)) {
            $focusPointX = ($focusPointX + 1) / 2;
            $focusPointY = ($focusPointY + 1) / 2;

            $imgproxyUrl->addProcessingOption('gravity:fp', $focusPointX . ':' . $focusPointY);
        }

        return parent::generateUrl($imgproxyUrl);
    }
}
```

Configuration/Objects.yaml:
```
'Networkteam\ImageProxy\ImgproxyBuilderInterface':
  className: Vendor\ImgProxy\ImgproxyBuilder
```

Please let me know what you think about this, if this meets your expectations I would also add the example to the README file.


Regards,
Cyrill